### PR TITLE
Feat : 서류 결과 조회 기능 구현

### DIFF
--- a/src/main/java/com/likelion/officialsite/controller/ApplicationController.java
+++ b/src/main/java/com/likelion/officialsite/controller/ApplicationController.java
@@ -1,4 +1,0 @@
-package com.likelion.officialsite.controller;
-
-public class ApplicationController {
-}

--- a/src/main/java/com/likelion/officialsite/controller/ResultController.java
+++ b/src/main/java/com/likelion/officialsite/controller/ResultController.java
@@ -1,0 +1,30 @@
+package com.likelion.officialsite.controller;
+
+import com.likelion.officialsite.dto.request.ResultRequestDto;
+import com.likelion.officialsite.dto.response.ApiResponse;
+import com.likelion.officialsite.dto.response.DocumentResultResponseDto;
+import com.likelion.officialsite.service.ResultService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/result")
+@RequiredArgsConstructor
+public class ResultController {
+
+    private final ResultService resultService;
+
+    @GetMapping("/document")
+    public ResponseEntity<ApiResponse<DocumentResultResponseDto>> getDocumentResult(@RequestBody ResultRequestDto resultRequestDto){
+
+        DocumentResultResponseDto documentResultResponse  = resultService.getDocumentResult(resultRequestDto);
+        ApiResponse<DocumentResultResponseDto> response =  new ApiResponse<>(true,"200","서류 전형 결과 조회를 성공",documentResultResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/final")
+    public void getFinalResult(ResultRequestDto resultRequestDto){
+
+    }
+}

--- a/src/main/java/com/likelion/officialsite/dto/request/ApplicationRequestDto.java
+++ b/src/main/java/com/likelion/officialsite/dto/request/ApplicationRequestDto.java
@@ -1,4 +1,0 @@
-package com.likelion.officialsite.dto.request;
-
-public class ApplicationRequestDto {
-}

--- a/src/main/java/com/likelion/officialsite/dto/request/ResultRequestDto.java
+++ b/src/main/java/com/likelion/officialsite/dto/request/ResultRequestDto.java
@@ -1,0 +1,13 @@
+package com.likelion.officialsite.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResultRequestDto {
+
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/likelion/officialsite/dto/response/ApiResponse.java
+++ b/src/main/java/com/likelion/officialsite/dto/response/ApiResponse.java
@@ -1,0 +1,15 @@
+package com.likelion.officialsite.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private String code;
+    private String message;
+    private T data;  // 응답 데이터를 담을 필드
+}

--- a/src/main/java/com/likelion/officialsite/dto/response/DocumentResultResponseDto.java
+++ b/src/main/java/com/likelion/officialsite/dto/response/DocumentResultResponseDto.java
@@ -1,0 +1,19 @@
+package com.likelion.officialsite.dto.response;
+
+import com.likelion.officialsite.entity.InterviewTime;
+import com.likelion.officialsite.enums.Status;
+import com.likelion.officialsite.enums.Track;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class DocumentResultResponseDto {
+
+    private Status status;
+    private Track track;
+    private String name;
+    private InterviewTime confirmedInterviewTime;
+}

--- a/src/main/java/com/likelion/officialsite/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/officialsite/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.likelion.officialsite.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    //success
+    SUCCESS(true, HttpStatus.OK.value(), "요청에 성공했습니다."),
+    CREATED(true, HttpStatus.CREATED.value(), "생성에 성공했습니다."),
+    ;
+
+
+    private final Boolean success;
+    private final int code;
+    private final String message;
+
+    ErrorCode(boolean success, int code, String message) {
+        this.success = success;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.likelion.officialsite.exception;
+
+import com.likelion.officialsite.dto.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler()
+    public ResponseEntity<ApiResponse<Void>> handleInvalidEmail(InvalidEmailException ex){
+        ApiResponse<Void> response = new ApiResponse<>(false,"400",ex.getMessage(),null);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidPassword(InvalidPasswordException ex) {
+        ApiResponse<Void> response = new ApiResponse<>(false, "401", ex.getMessage(), null);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/exception/InvalidEmailException.java
+++ b/src/main/java/com/likelion/officialsite/exception/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package com.likelion.officialsite.exception;
+
+public class InvalidEmailException extends  RuntimeException{
+
+    public InvalidEmailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/exception/InvalidPasswordException.java
+++ b/src/main/java/com/likelion/officialsite/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.likelion.officialsite.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/repository/ApplicationRepository.java
+++ b/src/main/java/com/likelion/officialsite/repository/ApplicationRepository.java
@@ -1,4 +1,0 @@
-package com.likelion.officialsite.repository;
-
-public class ApplicationRepository {
-}

--- a/src/main/java/com/likelion/officialsite/repository/ApplicationRespository.java
+++ b/src/main/java/com/likelion/officialsite/repository/ApplicationRespository.java
@@ -1,0 +1,11 @@
+package com.likelion.officialsite.repository;
+
+import com.likelion.officialsite.entity.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ApplicationRespository extends JpaRepository<Application,Long> {
+
+    Optional<Application> findByEmail(String email);
+}

--- a/src/main/java/com/likelion/officialsite/service/ApplicationService.java
+++ b/src/main/java/com/likelion/officialsite/service/ApplicationService.java
@@ -1,4 +1,0 @@
-package com.likelion.officialsite.service;
-
-public class ApplicationService {
-}

--- a/src/main/java/com/likelion/officialsite/service/ResultService.java
+++ b/src/main/java/com/likelion/officialsite/service/ResultService.java
@@ -1,0 +1,57 @@
+package com.likelion.officialsite.service;
+
+import com.likelion.officialsite.dto.request.ResultRequestDto;
+import com.likelion.officialsite.dto.response.ApiResponse;
+import com.likelion.officialsite.dto.response.DocumentResultResponseDto;
+import com.likelion.officialsite.entity.Application;
+import com.likelion.officialsite.exception.InvalidEmailException;
+import com.likelion.officialsite.exception.InvalidPasswordException;
+import com.likelion.officialsite.repository.ApplicationRespository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ResultService {
+
+    private final ApplicationRespository applicationRespository;
+
+    /**
+     * 1차 서류 결과 조회
+     */
+    public DocumentResultResponseDto getDocumentResult(ResultRequestDto resultRequestDto){
+
+
+        Application application = applicationRespository.findByEmail(resultRequestDto.getEmail())
+                .orElse(null);
+
+        if(application == null){ //존재하지 않는 이메일일 때
+            throw  new InvalidEmailException("유효하지 않는 이메일입니다");
+        }else{ //존재하지만 비밀번호가 틀릴 때
+            if(!application.getPassword().equals(resultRequestDto.getPassword())){
+                throw  new InvalidPasswordException("비밀번호가 틀렸습니다");
+            }
+        }
+
+
+        return toDocumentResultResponseDto(application);
+    }
+
+    /**
+     * Applicant 엔티티 -> ApplicantResponseDto 변환
+     */
+    private DocumentResultResponseDto toDocumentResultResponseDto(Application application) {
+        return DocumentResultResponseDto.builder()
+                .name(application.getName())
+                .track(application.getTrack())
+                .status(application.getStatus())
+                .confirmedInterviewTime(application.getConfirmedInterviewTime())
+                .build();
+    }
+}
+
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
   jpa:
     database: postgresql
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] 서류 결과 조회 기능 

## 💡 자세한 설명

1차 서류 전형 결과 확인 버튼 클릭 시 결과 조회 기능 구현 

![image](https://github.com/user-attachments/assets/6a4b9587-a4e3-4268-a437-741bf58d5484)

## 📢 리뷰 요구 사항 

예외 처리 확인해주세요. 
추가로 필요한 예외가 있는지 확인해주세요. 
- 유효하지 않는 이메일
- 유효한 이메일이지만 틀린 비밀번호

## 🚩 후속 작업 (선택)
- 2차 최종 결과와 공통된 메서드 리팩토링

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?
