### PR TITLE
Refactor: smtp 이용 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'//.env 파일 활성화
 	implementation 'com.github.in-seo:univcert:master-SNAPSHOT' //univcert
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/officialsite/config/RedisConfig.java
+++ b/src/main/java/com/likelion/officialsite/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.likelion.officialsite.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/likelion/officialsite/controller/AuthController.java
+++ b/src/main/java/com/likelion/officialsite/controller/AuthController.java
@@ -14,59 +14,59 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-    private final AuthService authService;
-
-    @PostMapping("/send-code/signup")
-    public ResponseEntity<ApiResponse> sendSignupCode(@RequestBody SendCodeRequestDto requestDto){
-        ApiResponse response=authService.sendSignupCode(requestDto);
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/send-code/reset")
-    public ResponseEntity<ApiResponse> sendResetCode(@RequestBody SendCodeRequestDto requestDto){
-        ApiResponse response=authService.sendResetCode(requestDto);
-        return ResponseEntity.ok(response);
-    }
-
-
-    @PostMapping("/verify-code")
-    public ResponseEntity<ApiResponse> verifyCode(@RequestBody VerifyCodeRequestDto requestDto){
-        ApiResponse response=authService.verifyCode(requestDto);
-        return ResponseEntity.ok(response);
-
-    }
-
-    @PostMapping("/reset-password")
-    public ResponseEntity<ApiResponse> resetPassword(@RequestBody ResetPasswordDto requestDto ){
-        authService.resetPassword(requestDto);
-        return ResponseEntity.ok(new ApiResponse(true,200,"비밀번호 변경 완료"));
-    }
-
-    // 특정 이메일 인증 초기화
-    @PostMapping("/clear-certification/email")
-    public ResponseEntity<ApiResponse> clearCertificationByEmail(@RequestBody EmailRequestDto requestDto) {
-        ApiResponse response = authService.clearCertificationByEmail(requestDto.getEmail());
-        return ResponseEntity.ok(response);
-    }
-
-    // 전체 인증된 이메일 초기화
-    @PostMapping("/clear-certification/all")
-    public ResponseEntity<ApiResponse> clearAllCertifications() {
-        ApiResponse response = authService.clearAllCertifications();
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/check-status")
-    public ResponseEntity<ApiResponse> checkEmailStatus(@RequestBody EmailRequestDto requestDto) {
-        ApiResponse response = authService.checkEmailStatus(requestDto.getEmail());
-        return ResponseEntity.ok(response);
-    }
-
-    // 인증된 사용자 목록 조회
-    @GetMapping("/certified-users")
-    public ResponseEntity<ApiResponse> getCertifiedUsers() {
-        ApiResponse response = authService.getCertifiedUsers();
-        return ResponseEntity.ok(response);
-    }
+//    private final AuthService authService;
+//
+//    @PostMapping("/send-code/signup")
+//    public ResponseEntity<ApiResponse> sendSignupCode(@RequestBody SendCodeRequestDto requestDto){
+//        ApiResponse response=authService.sendSignupCode(requestDto);
+//        return ResponseEntity.ok(response);
+//    }
+//
+//    @PostMapping("/send-code/reset")
+//    public ResponseEntity<ApiResponse> sendResetCode(@RequestBody SendCodeRequestDto requestDto){
+//        ApiResponse response=authService.sendResetCode(requestDto);
+//        return ResponseEntity.ok(response);
+//    }
+//
+//
+//    @PostMapping("/verify-code")
+//    public ResponseEntity<ApiResponse> verifyCode(@RequestBody VerifyCodeRequestDto requestDto){
+//        ApiResponse response=authService.verifyCode(requestDto);
+//        return ResponseEntity.ok(response);
+//
+//    }
+//
+//    @PostMapping("/reset-password")
+//    public ResponseEntity<ApiResponse> resetPassword(@RequestBody ResetPasswordDto requestDto ){
+//        authService.resetPassword(requestDto);
+//        return ResponseEntity.ok(new ApiResponse(true,200,"비밀번호 변경 완료"));
+//    }
+//
+//    // 특정 이메일 인증 초기화
+//    @PostMapping("/clear-certification/email")
+//    public ResponseEntity<ApiResponse> clearCertificationByEmail(@RequestBody EmailRequestDto requestDto) {
+//        ApiResponse response = authService.clearCertificationByEmail(requestDto.getEmail());
+//        return ResponseEntity.ok(response);
+//    }
+//
+//    // 전체 인증된 이메일 초기화
+//    @PostMapping("/clear-certification/all")
+//    public ResponseEntity<ApiResponse> clearAllCertifications() {
+//        ApiResponse response = authService.clearAllCertifications();
+//        return ResponseEntity.ok(response);
+//    }
+//
+//    @PostMapping("/check-status")
+//    public ResponseEntity<ApiResponse> checkEmailStatus(@RequestBody EmailRequestDto requestDto) {
+//        ApiResponse response = authService.checkEmailStatus(requestDto.getEmail());
+//        return ResponseEntity.ok(response);
+//    }
+//
+//    // 인증된 사용자 목록 조회
+//    @GetMapping("/certified-users")
+//    public ResponseEntity<ApiResponse> getCertifiedUsers() {
+//        ApiResponse response = authService.getCertifiedUsers();
+//        return ResponseEntity.ok(response);
+//    }
 
 }

--- a/src/main/java/com/likelion/officialsite/controller/MailController.java
+++ b/src/main/java/com/likelion/officialsite/controller/MailController.java
@@ -1,0 +1,47 @@
+package com.likelion.officialsite.controller;
+
+import com.likelion.officialsite.dto.request.EmailRequestDto;
+import com.likelion.officialsite.dto.request.ResetPasswordDto;
+import com.likelion.officialsite.dto.request.SendCodeRequestDto;
+import com.likelion.officialsite.dto.request.VerifyCodeRequestDto;
+import com.likelion.officialsite.dto.response.ApiResponse;
+import com.likelion.officialsite.service.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mail")
+public class MailController {
+
+    private final MailService mailService;
+
+    @PostMapping("/send-code/signup")
+    public ResponseEntity<ApiResponse> sendSignupCode(@RequestBody SendCodeRequestDto requestDto){
+        ApiResponse response=mailService.sendSignupCode(requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/send-code/reset")
+    public ResponseEntity<ApiResponse> sendResetCode(@RequestBody SendCodeRequestDto requestDto){
+        ApiResponse response=mailService.sendResetCode(requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<ApiResponse> verifyCode(@RequestBody VerifyCodeRequestDto requestDto){
+        ApiResponse response=mailService.verifyCode(requestDto);
+        return ResponseEntity.ok(response);
+
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse> resetPassword(@RequestBody ResetPasswordDto requestDto ){
+        mailService.resetPassword(requestDto);
+        return ResponseEntity.ok(new ApiResponse(true,200,"비밀번호 변경 완료"));
+    }
+
+
+}

--- a/src/main/java/com/likelion/officialsite/dto/request/VerifyCodeRequestDto.java
+++ b/src/main/java/com/likelion/officialsite/dto/request/VerifyCodeRequestDto.java
@@ -7,5 +7,5 @@ import lombok.Setter;
 @Setter
 public class VerifyCodeRequestDto {
     private String email;
-    private int code;
+    private String code;
 }

--- a/src/main/java/com/likelion/officialsite/entity/RedisUtil.java
+++ b/src/main/java/com/likelion/officialsite/entity/RedisUtil.java
@@ -1,0 +1,34 @@
+package com.likelion.officialsite.entity;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final StringRedisTemplate template;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(template.hasKey(key));
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        template.delete(key);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/service/AuthService.java
+++ b/src/main/java/com/likelion/officialsite/service/AuthService.java
@@ -8,184 +8,197 @@ import com.likelion.officialsite.entity.Application;
 import com.likelion.officialsite.exception.*;
 import com.likelion.officialsite.repository.ApplicationRepository;
 import com.univcert.api.UnivCert;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    @Value("${univcert.api-key}")
-    private String key;
-    @Value("${univcert.univ-name}")
-    private String univName;
-    private final ApplicationRepository applicationRepository;
-
-    //지원서 신규 생성 - 인증 코드 전송
-    public ApiResponse sendSignupCode(SendCodeRequestDto requestDto)  {
-        String email=requestDto.getEmail();
-        validateEmail(email);
-        if(applicationRepository.existsByEmail(email)){
-            throw new DuplicateEmailException("이미 존재하는 이메일입니다.");
-        }
-        return sendCode(requestDto);
-    }
-
-    //비밀번호 재설정 - 인증 코드 전송
-    public ApiResponse sendResetCode(SendCodeRequestDto requestDto)  {
-        String email=requestDto.getEmail();
-        validateEmail(email);
-        if(!applicationRepository.existsByEmail(email)){
-            throw new UserNotFoundException("존재하지 않는 회원입니다.");
-        }
-        return sendCode(requestDto);
-    }
-
-    //이메일 검증
-    private void validateEmail(String email){
-        if(email==null){
-            throw new EmailValidationException("이메일을 입력해야 합니다.");
-        }
-
-        String emailPattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
-        if(!Pattern.matches(emailPattern,email)){
-            throw new EmailValidationException("올바르지 않은 이메일 형식입니다.");
-        }
-
-        if(!email.endsWith("@sogang.ac.kr")){
-            throw new EmailValidationException("서강대학교 이메일만 입력할 수 있습니다.");
-        }
-    }
-
-    private ApiResponse sendCode(SendCodeRequestDto requestDto){
-
-        try {
-            Map<String, Object> result = UnivCert.certify(key, requestDto.getEmail(), univName, true);
-
-            if ((boolean) result.get("success")) {
-                return new ApiResponse(true,  200,"인증 코드를 성공적으로 전송했습니다.");
-            } else {
-                String message = result.get("message") != null ? result.get("message").toString() : "인증 과정에서 오류가 발생했습니다."; //메시지가 null일 경우
-                throw new VerificationFailedException(message);
-            }
-
-        } catch (IOException e) {
-            throw new UnivCertApiException("인증 API 통신 중 오류 발생", e);
-        }
-
-    }
-
-
-    //인증코드 검증
-    public ApiResponse verifyCode(VerifyCodeRequestDto requestDto)  {
-
-        try {
-            Map<String, Object> result = UnivCert.certifyCode(key, requestDto.getEmail(), univName, requestDto.getCode());
-
-            if ((boolean) result.get("success")) {
-                UnivCert.clear(key, requestDto.getEmail()); //인증 후 목록에서 삭제
-                return new ApiResponse(true, 200,"서강대학교 학생 인증에 성공했습니다.");
-            } else {
-                String message = result.get("message") != null ? result.get("message").toString() : "인증 과정에서 오류가 발생했습니다."; //메시지가 null일 경우
-                throw new VerificationFailedException(message);
-            }
-            
-        } catch (IOException e) {
-            throw new UnivCertApiException("인증 API 통신 중 오류 발생", e);
-        }
-
-    }
-
-    //비밀번호 재설정
-    public void resetPassword(ResetPasswordDto requestDto)  {
-        Application app=applicationRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(()->new UserNotFoundException("존재하지 않는 회원입니다."));
-        validatePassword(requestDto.getPassword());
-        //비밀번호 해싱 적용하기??나중에ㅎ
-        app.updatePassword(requestDto.getPassword());
-        applicationRepository.save(app);
-
-    }
-
-    private void validatePassword(String password) {
-        String passwordPattern = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()-_+=]{8,20}$";
-        if (!Pattern.matches(passwordPattern, password)) {
-            throw new InvalidPasswordException("비밀번호는 8~20자의 영문과 숫자를 포함해야 합니다.");
-        }
-    }
-
-
-
-    // 특정 이메일 인증 초기화
-    public ApiResponse clearCertificationByEmail(String email) {
-        try {
-            UnivCert.clear(key, email);
-            return new ApiResponse(true, 200, "해당 이메일의 인증 기록이 삭제되었습니다.");
-        } catch (IOException e) {
-            throw new UnivCertApiException("이메일 인증 삭제 중 오류 발생", e);
-        }
-    }
-
-    // 전체 인증된 이메일 초기화
-    public ApiResponse clearAllCertifications() {
-        try {
-            Map<String, String> requestBody = new HashMap<>();
-            requestBody.put("key", key);
-
-            Map<String, Object> response = UnivCert.clear(key);
-            boolean success = (boolean) response.get("success");
-
-            if (success) {
-                return new ApiResponse(true, 200, "모든 이메일의 인증 기록이 초기화되었습니다.");
-            } else {
-                String message = response.get("message") != null ? response.get("message").toString() : "초기화 과정에서 오류가 발생했습니다.";
-                return new ApiResponse(false, 400, message);
-            }
-        } catch (IOException e) {
-            throw new UnivCertApiException("전체 이메일 인증 삭제 중 오류 발생", e);
-        }
-    }
-
-    public ApiResponse checkEmailStatus(String email) {
-        try {
-            Map<String, Object> result = UnivCert.status(key, email);
-            boolean isVerified = (boolean) result.get("success");
-
-            if (isVerified) {
-                return new ApiResponse(true, 200, "이메일이 인증된 상태입니다.");
-            } else {
-                String message = result.get("message") != null ? result.get("message").toString() : "이메일 인증이 완료되지 않았습니다.";
-                return new ApiResponse(false, 400, message);
-            }
-        } catch (IOException e) {
-            throw new UnivCertApiException("UnivCert API 통신 중 오류 발생", e);
-        }
-    }
-
-    // 인증된 사용자 목록 조회
-    public ApiResponse getCertifiedUsers() {
-        try {
-            Map<String, Object> response = UnivCert.list(key);
-            boolean success = (boolean) response.get("success");
-
-            if (success) {
-                List<Map<String, Object>> certifiedUsers = (List<Map<String, Object>>) response.get("data");
-                return new ApiResponse(true, 200, "인증된 사용자 목록 조회 성공", certifiedUsers);
-            } else {
-                String message = response.get("message") != null ? response.get("message").toString() : "사용자 목록 조회 중 오류 발생";
-                return new ApiResponse(false, 400, message);
-            }
-        } catch (IOException e) {
-            throw new UnivCertApiException("UnivCert API 통신 중 오류 발생", e);
-        }
-    }
-
+//    @Value("${univcert.api-key}")
+//    private String key;
+//    @Value("${univcert.univ-name}")
+//    private String univName;
+//    private final RedisTemplate<String, String> redisTemplate;
+//    private static final long EXPIRATION_MINUTES = 5; // 5분 만료
+//
+//    private final ApplicationRepository applicationRepository;
+//
+//
+//
+//
+//    //지원서 신규 생성 - 인증 코드 전송
+//    public ApiResponse sendSignupCode(SendCodeRequestDto requestDto)  {
+//        String email=requestDto.getEmail();
+//        validateEmail(email);
+//        if(applicationRepository.existsByEmail(email)){
+//            throw new DuplicateEmailException("이미 존재하는 이메일입니다.");
+//        }
+//        return sendCode(requestDto);
+//    }
+//
+//    //비밀번호 재설정 - 인증 코드 전송
+//    public ApiResponse sendResetCode(SendCodeRequestDto requestDto)  {
+//        String email=requestDto.getEmail();
+//        validateEmail(email);
+//        if(!applicationRepository.existsByEmail(email)){
+//            throw new UserNotFoundException("존재하지 않는 회원입니다.");
+//        }
+//        return sendCode(requestDto);
+//    }
+//
+//    //이메일 검증
+//    private void validateEmail(String email){
+//        if(email==null){
+//            throw new EmailValidationException("이메일을 입력해야 합니다.");
+//        }
+//
+//        String emailPattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+//        if(!Pattern.matches(emailPattern,email)){
+//            throw new EmailValidationException("올바르지 않은 이메일 형식입니다.");
+//        }
+//
+//        if(!email.endsWith("@sogang.ac.kr")){
+//            throw new EmailValidationException("서강대학교 이메일만 입력할 수 있습니다.");
+//        }
+//    }
+//
+//    private ApiResponse sendCode(SendCodeRequestDto requestDto){
+//
+//        try {
+//            Map<String, Object> result = UnivCert.certify(key, requestDto.getEmail(), univName, true);
+//
+//            if ((boolean) result.get("success")) {
+//                return new ApiResponse(true,  200,"인증 코드를 성공적으로 전송했습니다.");
+//            } else {
+//                String message = result.get("message") != null ? result.get("message").toString() : "인증 과정에서 오류가 발생했습니다."; //메시지가 null일 경우
+//                throw new VerificationFailedException(message);
+//            }
+//
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("인증 API 통신 중 오류 발생", e);
+//        }
+//
+//    }
+//
+//
+//    //인증코드 검증
+//    public ApiResponse verifyCode(VerifyCodeRequestDto requestDto)  {
+//
+//        try {
+//            Map<String, Object> result = UnivCert.certifyCode(key, requestDto.getEmail(), univName, requestDto.getCode());
+//
+//            if ((boolean) result.get("success")) {
+//                UnivCert.clear(key, requestDto.getEmail()); //인증 후 목록에서 삭제
+//                return new ApiResponse(true, 200,"서강대학교 학생 인증에 성공했습니다.");
+//            } else {
+//                String message = result.get("message") != null ? result.get("message").toString() : "인증 과정에서 오류가 발생했습니다."; //메시지가 null일 경우
+//                throw new VerificationFailedException(message);
+//            }
+//
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("인증 API 통신 중 오류 발생", e);
+//        }
+//
+//    }
+//
+//    //비밀번호 재설정
+//    public void resetPassword(ResetPasswordDto requestDto)  {
+//        Application app=applicationRepository.findByEmail(requestDto.getEmail())
+//                .orElseThrow(()->new UserNotFoundException("존재하지 않는 회원입니다."));
+//        validatePassword(requestDto.getPassword());
+//        //비밀번호 해싱 적용하기??나중에ㅎ
+//        app.updatePassword(requestDto.getPassword());
+//        applicationRepository.save(app);
+//
+//    }
+//
+//    private void validatePassword(String password) {
+//        String passwordPattern = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()-_+=]{8,20}$";
+//        if (!Pattern.matches(passwordPattern, password)) {
+//            throw new InvalidPasswordException("비밀번호는 8~20자의 영문과 숫자를 포함해야 합니다.");
+//        }
+//    }
+//
+//
+//
+//    // 특정 이메일 인증 초기화
+//    public ApiResponse clearCertificationByEmail(String email) {
+//        try {
+//            UnivCert.clear(key, email);
+//            return new ApiResponse(true, 200, "해당 이메일의 인증 기록이 삭제되었습니다.");
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("이메일 인증 삭제 중 오류 발생", e);
+//        }
+//    }
+//
+//    // 전체 인증된 이메일 초기화
+//    public ApiResponse clearAllCertifications() {
+//        try {
+//            Map<String, String> requestBody = new HashMap<>();
+//            requestBody.put("key", key);
+//
+//            Map<String, Object> response = UnivCert.clear(key);
+//            boolean success = (boolean) response.get("success");
+//
+//            if (success) {
+//                return new ApiResponse(true, 200, "모든 이메일의 인증 기록이 초기화되었습니다.");
+//            } else {
+//                String message = response.get("message") != null ? response.get("message").toString() : "초기화 과정에서 오류가 발생했습니다.";
+//                return new ApiResponse(false, 400, message);
+//            }
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("전체 이메일 인증 삭제 중 오류 발생", e);
+//        }
+//    }
+//
+//    public ApiResponse checkEmailStatus(String email) {
+//        try {
+//            Map<String, Object> result = UnivCert.status(key, email);
+//            boolean isVerified = (boolean) result.get("success");
+//
+//            if (isVerified) {
+//                return new ApiResponse(true, 200, "이메일이 인증된 상태입니다.");
+//            } else {
+//                String message = result.get("message") != null ? result.get("message").toString() : "이메일 인증이 완료되지 않았습니다.";
+//                return new ApiResponse(false, 400, message);
+//            }
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("UnivCert API 통신 중 오류 발생", e);
+//        }
+//    }
+//
+//    // 인증된 사용자 목록 조회
+//    public ApiResponse getCertifiedUsers() {
+//        try {
+//            Map<String, Object> response = UnivCert.list(key);
+//            boolean success = (boolean) response.get("success");
+//
+//            if (success) {
+//                List<Map<String, Object>> certifiedUsers = (List<Map<String, Object>>) response.get("data");
+//                return new ApiResponse(true, 200, "인증된 사용자 목록 조회 성공", certifiedUsers);
+//            } else {
+//                String message = response.get("message") != null ? response.get("message").toString() : "사용자 목록 조회 중 오류 발생";
+//                return new ApiResponse(false, 400, message);
+//            }
+//        } catch (IOException e) {
+//            throw new UnivCertApiException("UnivCert API 통신 중 오류 발생", e);
+//        }
+//    }
+//
 
 }

--- a/src/main/java/com/likelion/officialsite/service/MailService.java
+++ b/src/main/java/com/likelion/officialsite/service/MailService.java
@@ -1,0 +1,168 @@
+package com.likelion.officialsite.service;
+
+import com.likelion.officialsite.dto.request.ResetPasswordDto;
+import com.likelion.officialsite.dto.request.SendCodeRequestDto;
+import com.likelion.officialsite.dto.request.VerifyCodeRequestDto;
+import com.likelion.officialsite.dto.response.ApiResponse;
+import com.likelion.officialsite.entity.Application;
+import com.likelion.officialsite.entity.RedisUtil;
+import com.likelion.officialsite.exception.*;
+import com.likelion.officialsite.repository.ApplicationRepository;
+import com.univcert.api.UnivCert;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private static final String sender = "likelion.sgu@gmail.com"; //보내는 사람
+    private final JavaMailSender emailSender;
+    private final RedisUtil redisUtil;
+
+    private final SpringTemplateEngine templateEngine;
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final SecureRandom random = new SecureRandom();
+    private static final int CODE_LENGTH = 6;
+
+    private final ApplicationRepository applicationRepository;
+
+
+    // 인증번호 생성 (영문+숫자 조합)
+    public String createCode() {
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            code.append(CHARACTERS.charAt(random.nextInt(CHARACTERS.length())));
+        }
+        return code.toString();
+    }
+
+
+    //메일 양식
+    public MimeMessage createEmailForm(String email) throws MessagingException, UnsupportedEncodingException {
+
+        String authCode=createCode(); //인증 코드 생성
+
+        MimeMessage message = emailSender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, email); //보낼 이메일 설정
+        message.setSubject("서강대학교 멋쟁이 사자처럼 인증 번호"); //제목
+        message.setFrom(sender);
+        message.setText(setContext(authCode), "utf-8", "html");
+
+        //redis 인증코드 유효시간 설정
+        redisUtil.setDataExpire(email, authCode, 60 * 30L);
+        return message;
+    }
+
+    public void sendEmail(String email) throws MessagingException, UnsupportedEncodingException {
+        if(redisUtil.existData(email)){
+            redisUtil.deleteData(email);
+        }
+        MimeMessage emailForm = createEmailForm(email);
+        emailSender.send(emailForm);
+
+    }
+
+    public String setContext(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("mail", context); //mail.html
+    }
+
+    //지원서 신규 생성 - 인증 코드 전송
+    public ApiResponse sendSignupCode(SendCodeRequestDto requestDto)  {
+        String email=requestDto.getEmail();
+        validateEmail(email);
+        if(applicationRepository.existsByEmail(email)){
+            throw new DuplicateEmailException("이미 존재하는 이메일입니다.");
+        }
+        return sendCode(requestDto);
+    }
+
+    //비밀번호 재설정 - 인증 코드 전송
+    public ApiResponse sendResetCode(SendCodeRequestDto requestDto)  {
+        String email=requestDto.getEmail();
+        validateEmail(email);
+        if(!applicationRepository.existsByEmail(email)){
+            throw new UserNotFoundException("존재하지 않는 회원입니다.");
+        }
+        return sendCode(requestDto);
+    }
+
+    private ApiResponse sendCode(SendCodeRequestDto requestDto){
+
+        try {
+            sendEmail(requestDto.getEmail());
+            return new ApiResponse(true,  200,"인증 코드를 성공적으로 전송했습니다.");
+
+        } catch (IOException | MessagingException e) {
+            throw new UnivCertApiException("인증 API 통신 중 오류 발생", e);
+        }
+
+    }
+
+    //이메일 검증
+    private void validateEmail(String email){
+        if(email==null){
+            throw new EmailValidationException("이메일을 입력해야 합니다.");
+        }
+
+        String emailPattern="^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
+        if(!Pattern.matches(emailPattern,email)){
+            throw new EmailValidationException("올바르지 않은 이메일 형식입니다.");
+        }
+
+        if(!email.endsWith("@sogang.ac.kr")){
+            throw new EmailValidationException("서강대학교 이메일만 입력할 수 있습니다.");
+        }
+    }
+
+    //인증코드 검증
+    public ApiResponse verifyCode(VerifyCodeRequestDto requestDto) {
+        String foundCode=redisUtil.getData(requestDto.getEmail());
+        if(foundCode==null){
+            //예외처리
+        }
+        if(foundCode.equals(requestDto.getCode())){
+            return new ApiResponse(true,200,"서강대학교 학생 인증 성공");
+
+        }else{
+            return new ApiResponse(false,400,"인증번호가 일치하지 않습니다.");
+        }
+    }
+
+    //비밀번호 재설정
+    public void resetPassword(ResetPasswordDto requestDto)  {
+        Application app=applicationRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(()->new UserNotFoundException("존재하지 않는 회원입니다."));
+        validatePassword(requestDto.getPassword());
+        app.updatePassword(requestDto.getPassword());
+        applicationRepository.save(app);
+
+    }
+
+    private void validatePassword(String password) {
+        String passwordPattern = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()-_+=]{8,20}$";
+        if (!Pattern.matches(passwordPattern, password)) {
+            throw new InvalidPasswordException("비밀번호는 8~20자의 영문과 숫자를 포함해야 합니다.");
+        }
+    }
+
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,33 @@ spring:
         format_sql: true
     show-sql: true  # 콘솔에 SQL 로그 출력
 
+
+  data:
+    redis:
+      host: ${REDIS_IP}
+      port: ${REDIS_PORT}
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${SMTP_USER}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+      auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+
+
+
 univcert:
   api-key: ${UNIVCERT_API_KEY}
   univ-name: "서강대학교"
+
+

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>서강대학교 멋쟁이 사자처럼</title>
+</head>
+<body>
+<div style="margin:100px;">
+    <h1> 안녕하세요.</h1>
+    <h1> 서강대학교 멋쟁이 사장처럼입니다.</h1>
+    <br>
+    <p> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> 회원가입 인증 코드 입니다. </h3>
+        <div style="font-size:130%" th:text="${code}"> </div>
+    </div>
+    <br/>
+</div>
+
+
+</body>
+</html>
+
+


### PR DESCRIPTION
## 🎯 이슈 번호

## 💡 작업 내용

- [x] univcert -> google smtp 이메일 인증 구현

## 💡 자세한 설명

- 서강대학교 이메일만 가능
- 자체 인증코드 생성 후 이메일+코드 redis 저장 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
- 예외처리 해주세요..

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?
