### PR TITLE
Fix: 메일 관련 예외처리

### DIFF
--- a/src/main/java/com/likelion/officialsite/exception/EmailLimitExceededException.java
+++ b/src/main/java/com/likelion/officialsite/exception/EmailLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.likelion.officialsite.exception;
+
+public class EmailLimitExceededException extends RuntimeException {
+    public EmailLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/exception/EmailSendException.java
+++ b/src/main/java/com/likelion/officialsite/exception/EmailSendException.java
@@ -1,0 +1,11 @@
+package com.likelion.officialsite.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR) // 500 Internal Server Error
+public class EmailSendException extends RuntimeException {
+    public EmailSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
@@ -63,6 +63,12 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 서버와의 연결 중 오류가 발생했습니다.");
     }
 
+    @ExceptionHandler(EmailLimitExceededException.class)
+    public ResponseEntity<ApiResponse> handleEmailLimitExceededException(EmailLimitExceededException ex) {
+        return buildErrorResponse(HttpStatus.TOO_MANY_REQUESTS, ex.getMessage());
+    }
+
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleGenericException(Exception ex) {
         log.error("Unhandled exception: ", ex);  // 예외 메시지 출력

--- a/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/officialsite/exception/GlobalExceptionHandler.java
@@ -51,6 +51,18 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.BAD_REQUEST,ex.getMessage());
     }
 
+    @ExceptionHandler(EmailSendException.class)
+    public ResponseEntity<ApiResponse> handleEmailSendException(EmailSendException ex) {
+        log.error("이메일 전송 오류 발생: ", ex);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 오류가 발생했습니다.");
+    }
+
+    @ExceptionHandler(RedisConnectionException.class)
+    public ResponseEntity<ApiResponse> handleRedisConnectionException(RedisConnectionException ex) {
+        log.error("Redis 연결 오류 발생: ", ex);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 서버와의 연결 중 오류가 발생했습니다.");
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleGenericException(Exception ex) {
         log.error("Unhandled exception: ", ex);  // 예외 메시지 출력

--- a/src/main/java/com/likelion/officialsite/exception/RedisConnectionException.java
+++ b/src/main/java/com/likelion/officialsite/exception/RedisConnectionException.java
@@ -1,0 +1,11 @@
+package com.likelion.officialsite.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR) // 500 Internal Server Error
+public class RedisConnectionException extends RuntimeException {
+    public RedisConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/likelion/officialsite/service/MailService.java
+++ b/src/main/java/com/likelion/officialsite/service/MailService.java
@@ -59,7 +59,7 @@ public class MailService {
 
         MimeMessage message = emailSender.createMimeMessage();
         message.addRecipients(MimeMessage.RecipientType.TO, email); //보낼 이메일 설정
-        message.setSubject("서강대학교 멋쟁이 사자처럼 인증 번호"); //제목
+        message.setSubject("서강대학교 멋쟁이사자처럼 13기 인증 번호"); //제목
         message.setFrom(sender);
         message.setText(setContext(authCode), "utf-8", "html");
 

--- a/src/main/java/com/likelion/officialsite/service/MailService.java
+++ b/src/main/java/com/likelion/officialsite/service/MailService.java
@@ -72,9 +72,14 @@ public class MailService {
         if(redisUtil.existData(email)){
             redisUtil.deleteData(email);
         }
-        MimeMessage emailForm = createEmailForm(email);
-        emailSender.send(emailForm);
 
+        try {
+            redisUtil.setDataExpire("email_limit_" + email, "locked", 30);
+            MimeMessage emailForm = createEmailForm(email);
+            emailSender.send(emailForm);
+        } catch (MessagingException e) {
+            throw new EmailSendException("이메일 전송 중 오류 발생", e);
+        }
     }
 
     public String setContext(String code) {
@@ -133,27 +138,33 @@ public class MailService {
 
     //인증코드 검증
     public ApiResponse verifyCode(VerifyCodeRequestDto requestDto) {
-        String foundCode=redisUtil.getData(requestDto.getEmail());
-        if(foundCode==null){
-            //예외처리
-        }
-        if(foundCode.equals(requestDto.getCode())){
-            return new ApiResponse(true,200,"인증 성공");
+        String foundCode = redisUtil.getData(requestDto.getEmail());
 
-        }else{
-            return new ApiResponse(false,400,"인증번호가 일치하지 않습니다.");
+        if (foundCode == null) {  // Redis에 값이 없으면 예외 발생
+            throw new VerificationFailedException("인증 코드가 만료되었거나 존재하지 않습니다.");
         }
+
+        if (!foundCode.equals(requestDto.getCode())) {  // 코드 불일치 예외 발생
+            throw new VerificationFailedException("인증번호가 일치하지 않습니다.");
+        }
+
+        return new ApiResponse(true, 200, "인증 성공");
     }
+
 
     //비밀번호 재설정
-    public void resetPassword(ResetPasswordDto requestDto)  {
-        Application app=applicationRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(()->new UserNotFoundException("존재하지 않는 회원입니다."));
-        validatePassword(requestDto.getPassword());
-        app.updatePassword(passwordService.hashPassword(requestDto.getPassword())); //hash
-        applicationRepository.save(app);
+    public void resetPassword(ResetPasswordDto requestDto) {
+        Application app = applicationRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new UserNotFoundException("존재하지 않는 회원입니다."));
 
+        if (passwordService.verifyPassword(requestDto.getPassword(), app.getPassword())) {
+            throw new InvalidPasswordException("이전 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.");
+        }
+
+        app.updatePassword(passwordService.hashPassword(requestDto.getPassword()));
+        applicationRepository.save(app);
     }
+
 
     private void validatePassword(String password) {
         String passwordPattern = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()-_+=]{8,20}$";

--- a/src/main/java/com/likelion/officialsite/service/PasswordService.java
+++ b/src/main/java/com/likelion/officialsite/service/PasswordService.java
@@ -19,4 +19,12 @@ public class PasswordService {
         return passwordEncoder.matches(rawPassword, hashedPassword);
     }
 
+    /**
+     * 비밀번호 검증 (입력된 비밀번호와 기존 해시된 비밀번호 비교)
+     */
+    public boolean verifyPassword(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+
+
 }


### PR DESCRIPTION
## 🎯 
## 💡 작업 내용

- [x] 이메일 전송 실패 시 예외 
- [x] 레디스 연결 실패 시 예외
- [x] 레디스에 인증번호 만료 시/찾을 수 없을 때 예외 
- [x] 이전과 동일한 비밀번호로 재설정 시도 시 예외
- [x] 인증코드 만료 후 인증 시도했을때 예외


